### PR TITLE
unikernel: enable git-remote via ssh

### DIFF
--- a/.travis-test-mirage.sh
+++ b/.travis-test-mirage.sh
@@ -2,6 +2,7 @@
 
 eval `opam config env`
 
+opam repo add -y future git+https://github.com/roburio/git-ssh-dns-mirage3-repo.git
 opam update
 opam upgrade -y
 opam install -y mirage

--- a/.travis-test-mirage.sh
+++ b/.travis-test-mirage.sh
@@ -2,9 +2,6 @@
 
 eval `opam config env`
 
-opam repo add -y future git+https://github.com/roburio/git-ssh-dns-mirage3-repo.git
-opam update
-opam upgrade -y
 opam install -y mirage
 
 cd mirage

--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ Then, you need to install [`opam`](https://opam.ocaml.org) via your package mana
 Make sure you have OCaml version `>=4.07.0`, and opam version `>=2.0.0` and mirage version `>=3.7.1` installed via your package manager.
 You can use `ocaml --version`, `opam --version`, and `mirage --version` to find out.
 
+In addition, you currently need our opam repository overlay because we need some
+libraries that are not yet released for git-via-ssh. It is recommended to use a custom opam switch:
+
+    opam switch create caldav 4.07.1
+    opam repo add git-ssh-dns git+https://github.com/roburio/git-ssh-dns-mirage3-repo.git
+    opam install lwt mirage
+
 Now we're ready to compile the CalDAV server. Let's get the code (don't worry that we already pinned caldav, we now need the source code of the unikernel):
 
-    git clone https://github.com/roburio/caldav.git
+    git clone -b future https://github.com/roburio/caldav.git
     cd caldav/mirage
     mirage configure // -t xen / -t hvt works as well
     make depend

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ You can choose any not-yet-used username and password, an account will be create
 
 To begin the installation, you need to `ssh` into your server.
 Then, you need to install [`opam`](https://opam.ocaml.org) via your package manager (e.g. `apt install opam`).
-Make sure you have OCaml version `>=4.07.0`, and opam version `>=2.0.0` and mirage version `>=3.7.1` installed via your package manager.
+Make sure you have OCaml version `>=4.10.0`, and opam version `>=2.0.0` and mirage version `>=3.7.1` installed via your package manager.
 You can use `ocaml --version`, `opam --version`, and `mirage --version` to find out.
 
 In addition, you currently need our opam repository overlay because we need some
 libraries that are not yet released for git-via-ssh. It is recommended to use a custom opam switch:
 
-    opam switch create caldav 4.07.1
-    opam repo add git-ssh-dns git+https://github.com/roburio/git-ssh-dns-mirage3-repo.git
+    opam switch create caldav 4.11.1
+    eval `opam env`
     opam install lwt mirage
+    opam pin add caldav https://github.com/roburio/caldav.git
 
 Now we're ready to compile the CalDAV server. Let's get the code (don't worry that we already pinned caldav, we now need the source code of the unikernel):
 
-    git clone -b future https://github.com/roburio/caldav.git
+    git clone https://github.com/roburio/caldav.git
     cd caldav/mirage
     mirage configure // -t xen / -t hvt works as well
     make depend

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -2,6 +2,14 @@ open Mirage
 
 let net = generic_stackv4 default_network
 
+let seed =
+  let doc = Key.Arg.info ~doc:"Seed for the ssh private key." ["seed"] in
+  Key.(create "seed" Arg.(opt string "" doc))
+
+let authenticator =
+  let doc = Key.Arg.info ~doc:"Authenticator for SSH." ["authenticator"] in
+  Key.(create "authenticator" Arg.(opt string "" doc))
+
 (* set ~tls to false to get a plain-http server *)
 let http_srv = cohttp_server @@ conduit_direct ~tls:true net
 
@@ -46,7 +54,8 @@ let main =
     package ~min:"2.0.0" "irmin-mirage-git" ;
   ] in
   let keys =
-    [ Key.abstract http_port ; Key.abstract https_port ;
+    [ Key.abstract seed ; Key.abstract authenticator ;
+      Key.abstract http_port ; Key.abstract https_port ;
       Key.abstract admin_password ; Key.abstract remote ;
       Key.abstract tofu ; Key.abstract hostname ;
       Key.abstract apple_testable ]

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -48,7 +48,7 @@ let apple_testable =
 let main =
   let direct_dependencies = [
     package "uri" ;
-    package ~pin:"git+https://github.com/roburio/caldav.git" "caldav" ;
+    package "caldav" ;
     package ~min:"0.1.3" "icalendar" ;
     package ~min:"2.0.0" "irmin-git" ;
     package ~min:"2.0.0" "irmin-mirage-git" ;

--- a/mirage/config.ml
+++ b/mirage/config.ml
@@ -1,14 +1,123 @@
 open Mirage
 
+(* boilerplate from https://github.com/mirage/ocaml-git.git unikernel/config.ml
+   (commit #2220ba7fe749d228a52e52f25f3761575269a98a) *)
+type mimic = Mimic
+
+let mimic = typ Mimic
+
+let mimic_count =
+  let v = ref (-1) in
+  fun () -> incr v ; !v
+
+let mimic_conf () =
+  let packages = [ package "mimic" ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = mimic @-> mimic @-> mimic
+       method module_name = "Mimic.Merge"
+       method! packages = Key.pure packages
+       method name = Fmt.str "merge_ctx%02d" (mimic_count ())
+       method! connect _ _modname =
+         function
+         | [ a; b ] -> Fmt.str "Lwt.return (Mimic.merge %s %s)" a b
+         | [ x ] -> Fmt.str "%s.ctx" x
+         | _ -> Fmt.str "Lwt.return Mimic.empty"
+     end
+
+let merge ctx0 ctx1 = mimic_conf () $ ctx0 $ ctx1
+
+let mimic_tcp_conf =
+  let packages = [ package "git-mirage" ~sublibs:[ "tcp" ] ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = stackv4 @-> mimic
+       method module_name = "Git_mirage_tcp.Make"
+       method! packages = Key.pure packages
+       method name = "tcp_ctx"
+       method! connect _ modname = function
+         | [ stack ] ->
+           Fmt.str {ocaml|Lwt.return (%s.with_stack %s %s.ctx)|ocaml}
+             modname stack modname
+         | _ -> assert false
+     end
+
+let mimic_tcp_impl stackv4 = mimic_tcp_conf $ stackv4
+
+let mimic_ssh_conf ~kind ~seed ~auth =
+  let seed = Key.abstract seed in
+  let auth = Key.abstract auth in
+  let packages = [ package "git-mirage" ~sublibs:[ "ssh" ] ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = stackv4 @-> mimic @-> mclock @-> mimic
+       method! keys = [ seed; auth; ]
+       method module_name = "Git_mirage_ssh.Make"
+       method! packages = Key.pure packages
+       method name = match kind with
+         | `Rsa -> "ssh_rsa_ctx"
+         | `Ed25519 -> "ssh_ed25519_ctx"
+       method! connect _ modname =
+         function
+         | [ _; tcp_ctx; _ ] ->
+             let with_key =
+               match kind with
+               | `Rsa -> "with_rsa_key"
+               | `Ed25519 -> "with_ed25519_key"
+             in
+             Fmt.str
+               {ocaml|let ssh_ctx00 = Mimic.merge %s %s.ctx in
+                      let ssh_ctx01 = Option.fold ~none:ssh_ctx00 ~some:(fun v -> %s.%s v ssh_ctx00) %a in
+                      let ssh_ctx02 = Option.fold ~none:ssh_ctx01 ~some:(fun v -> %s.with_authenticator v ssh_ctx01) %a in
+                      Lwt.return ssh_ctx02|ocaml}
+               tcp_ctx modname
+               modname with_key Key.serialize_call seed
+               modname Key.serialize_call auth
+         | _ -> assert false
+     end
+
+let mimic_ssh_impl ~kind ~seed ~auth stackv4 mimic_git mclock =
+  mimic_ssh_conf ~kind ~seed ~auth
+  $ stackv4
+  $ mimic_git
+  $ mclock
+
+(* TODO(dinosaure): user-defined nameserver and port. *)
+
+let mimic_dns_conf =
+  let packages = [ package "git-mirage" ~sublibs:[ "dns" ] ] in
+  impl @@ object
+       inherit base_configurable
+       method ty = random @-> mclock @-> time @-> stackv4 @-> mimic @-> mimic
+       method module_name = "Git_mirage_dns.Make"
+       method! packages = Key.pure packages
+       method name = "dns_ctx"
+       method! connect _ modname =
+         function
+         | [ _; _; _; stack; tcp_ctx ] ->
+             Fmt.str
+               {ocaml|let dns_ctx00 = Mimic.merge %s %s.ctx in
+                      let dns_ctx01 = %s.with_dns %s dns_ctx00 in
+                      Lwt.return dns_ctx01|ocaml}
+               tcp_ctx modname
+               modname stack
+         | _ -> assert false
+     end
+
+let mimic_dns_impl random mclock time stackv4 mimic_tcp =
+  mimic_dns_conf $ random $ mclock $ time $ stackv4 $ mimic_tcp
+
+(* --- end of copied code --- *)
+
 let net = generic_stackv4 default_network
 
 let seed =
   let doc = Key.Arg.info ~doc:"Seed for the ssh private key." ["seed"] in
-  Key.(create "seed" Arg.(opt string "" doc))
+  Key.(create "seed" Arg.(opt (some string) None doc))
 
 let authenticator =
   let doc = Key.Arg.info ~doc:"Authenticator for SSH." ["authenticator"] in
-  Key.(create "authenticator" Arg.(opt string "" doc))
+  Key.(create "authenticator" Arg.(opt (some string) None doc))
 
 (* set ~tls to false to get a plain-http server *)
 let http_srv = cohttp_server @@ conduit_direct ~tls:true net
@@ -31,7 +140,7 @@ let admin_password =
 
 let remote =
   let doc = Key.Arg.info ~doc:"Location of calendar data." [ "remote" ] ~docv:"REMOTE" in
-  Key.(create "remote" Arg.(opt string "" doc))
+  Key.(create "remote" Arg.(required string doc))
 
 let tofu =
   let doc = Key.Arg.info ~doc:"If a user does not exist, create them and give them a new calendar." [ "tofu" ] in
@@ -48,10 +157,11 @@ let apple_testable =
 let main =
   let direct_dependencies = [
     package "uri" ;
-    package "caldav" ;
+    package ~pin:"git+https://github.com/roburio/caldav.git#future" "caldav" ;
     package ~min:"0.1.3" "icalendar" ;
-    package ~min:"2.0.0" "irmin-git" ;
-    package ~min:"2.0.0" "irmin-mirage-git" ;
+    package ~min:"2.3.0" "irmin-git" ;
+    package ~min:"2.3.0" "irmin-mirage-git" ;
+    package ~min:"3.2.0" "git-mirage";
   ] in
   let keys =
     [ Key.abstract seed ; Key.abstract authenticator ;
@@ -62,7 +172,17 @@ let main =
   in
   foreign
     ~packages:direct_dependencies ~keys
-    "Unikernel.Main" (random @-> pclock @-> mclock @-> kv_ro @-> http @-> resolver @-> conduit @-> kv_ro @-> job)
+    "Unikernel.Main" (random @-> pclock @-> mimic @-> kv_ro @-> http @-> kv_ro @-> job)
+
+let mimic ~kind ~seed ~authenticator stackv4 random mclock time =
+  let mtcp = mimic_tcp_impl stackv4 in
+  let mdns = mimic_dns_impl random mclock time stackv4 mtcp in
+  let mssh = mimic_ssh_impl ~kind ~seed ~auth:authenticator stackv4 mtcp mclock in
+  merge mssh mdns
+
+let mimic =
+  mimic ~kind:`Rsa ~seed ~authenticator net
+    default_random default_monotonic_clock default_time
 
 let () =
-  register "caldav" [main $ default_random $ default_posix_clock $ default_monotonic_clock $ certs $ http_srv $ resolver_dns net $ conduit_direct ~tls:true net $ zap ]
+  register "caldav" [main $ default_random $ default_posix_clock $ mimic $ certs $ http_srv $ zap ]

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -24,6 +24,15 @@ module Main (R : Mirage_random.S) (Clock: Mirage_clock.PCLOCK) (Mclock: Mirage_c
         | Failure _ -> Lwt.fail_with "Could not find server.pem and server.key in the <working directory>/tls."
         | e -> Lwt.fail e)
 
+  let ssh_config () =
+    match Astring.String.cut ~sep:"://" (Key_gen.remote ()) with
+    | Some (pre, _) when
+        Astring.String.is_infix ~affix:"ssh" pre &&
+        not (String.equal (Key_gen.seed ()) "")  ->
+      Cohttp.Header.init_with "config"
+        (Key_gen.seed () ^ ":" ^ Key_gen.authenticator ())
+    | _ -> Cohttp.Header.init ()
+
   (* Redirect to the same address, but in https. *)
   let redirect port request _body =
     let redirect_port = match port with 443 -> None | x -> Some x in
@@ -119,7 +128,9 @@ module Main (R : Mirage_random.S) (Clock: Mirage_clock.PCLOCK) (Mclock: Mirage_c
             Fmt.(option ~none:(unit "no HTTP request") string) (Lwt.get http_req)
             Fmt.(option ~none:(unit "none") string) (Lwt.get user_agent)
         in
-        Store.connect git ~conduit ~author ~resolver ~msg (Key_gen.remote ()) >>= fun store ->
+        Conduit.with_ssh conduit (module Mclock) >>= fun conduit ->
+        let headers = ssh_config () in
+        Store.connect git ~headers ~conduit ~author ~resolver ~msg (Key_gen.remote ()) >>= fun store ->
         Dav.connect store config admin_pass
     in
     let hostname = Key_gen.hostname () in

--- a/mirage/unikernel.ml
+++ b/mirage/unikernel.ml
@@ -9,7 +9,7 @@ module Server_log = (val Logs.src_log server_src : Logs.LOG)
 let access_src = Logs.Src.create "http.access" ~doc:"HTTP server access log"
 module Access_log = (val Logs.src_log access_src : Logs.LOG)
 
-module Main (R : Mirage_random.S) (Clock: Mirage_clock.PCLOCK) (_ : sig end) (KEYS: Mirage_kv.RO) (S: HTTP) (Zap : Mirage_kv.RO) = struct
+module Main (R : Mirage_random.S) (Clock: Mirage_clock.PCLOCK) (_ : sig end) (Conduit : Conduit_mirage.S) (Resolver : Resolver_lwt.S) (KEYS: Mirage_kv.RO) (S: HTTP) (Zap : Mirage_kv.RO) = struct
   module X509 = Tls_mirage.X509(KEYS)(Clock)
   module Store = Irmin_mirage_git.KV_RW(Irmin_git.Mem)(Clock)
   module Dav_fs = Caldav.Webdav_fs.Make(Clock)(Store)
@@ -78,7 +78,8 @@ module Main (R : Mirage_random.S) (Clock: Mirage_clock.PCLOCK) (_ : sig end) (KE
     in
     S.make ~conn_closed ~callback ()
 
-  let start _random _clock ctx keys http zap =
+  let start _random _clock ctx conduit resolver keys http zap =
+    let ctx = Git_cohttp_mirage.with_conduit (Cohttp_mirage.Client.ctx resolver conduit) ctx in
     let author = Lwt.new_key ()
     and user_agent = Lwt.new_key ()
     and http_req = Lwt.new_key ()


### PR DESCRIPTION
this as well updates the installation instructions :) (and have the unikernel being build via CI)

downside is the usage of a custom opam overlay repository with all the previously pinned packages