### PR TITLE
Move batch to webdav_api

### DIFF
--- a/src/webdav_api.mli
+++ b/src/webdav_api.mli
@@ -36,13 +36,13 @@ sig
   val make_user : ?props:(Webdav_xml.fqname * Properties.property) list -> state -> Ptime.t -> config -> name:string -> password:string -> salt:Cstruct.t ->
     (Uri.t, [> `Conflict ]) result Lwt.t
   val change_user_password : state -> config -> name:string -> password:string -> salt:Cstruct.t -> (unit, [> `Internal_server_error ]) result Lwt.t
-  val delete_user : state -> config -> string -> (unit, [> `Internal_server_error | `Not_found ]) result Lwt.t
+  val delete_user : state -> config -> string -> (unit, [> `Internal_server_error | `Not_found | `Conflict ]) result Lwt.t
 
   val make_group : state -> Ptime.t -> config -> string -> string list -> (Uri.t, [> `Conflict ]) result Lwt.t
-  val enroll : state -> config -> member:string -> group:string -> unit Lwt.t
-  val resign : state -> config -> member:string -> group:string -> unit Lwt.t
-  val replace_group_members : state -> config -> string -> string list -> unit Lwt.t
-  val delete_group : state -> config -> string -> (unit, [> `Internal_server_error | `Not_found ]) result Lwt.t
+  val enroll : state -> config -> member:string -> group:string -> (unit, [> `Conflict ]) result Lwt.t
+  val resign : state -> config -> member:string -> group:string -> (unit, [> `Conflict ]) result Lwt.t
+  val replace_group_members : state -> config -> string -> string list -> (unit, [> `Conflict ]) result Lwt.t
+  val delete_group : state -> config -> string -> (unit, [> `Internal_server_error | `Not_found | `Conflict ]) result Lwt.t
 
   val initialize_fs : state -> Ptime.t -> config -> unit Lwt.t
   val initialize_fs_for_apple_testsuite : state -> Ptime.t -> config -> unit Lwt.t

--- a/src/webdav_fs.mli
+++ b/src/webdav_fs.mli
@@ -48,8 +48,10 @@ sig
 
   val mkdir : t -> dir -> Properties.t -> (unit, write_error) result Lwt.t
 
+  (** be careful to call only in a batch, since it writes two files *)
   val write : t -> file -> string -> Properties.t -> (unit, write_error) result Lwt.t
 
+  (** be careful to call only in a batch, since it removes two files *)
   val destroy : t -> file_or_dir -> (unit, write_error) result Lwt.t
 
   val pp_error : error Fmt.t
@@ -61,6 +63,8 @@ sig
   val last_modified : t -> file_or_dir -> (Ptime.t, error) result Lwt.t
 
   val etag : t -> file_or_dir -> (string, error) result Lwt.t
+
+  val batch: t -> ?retries:int -> (t -> 'a Lwt.t) -> 'a Lwt.t
 end
 
 module Make (Pclock : Mirage_clock.PCLOCK) (Fs: Mirage_kv.RW) : S with type t = Fs.t


### PR DESCRIPTION
if I understand the mirage-kv and irmin-git-mirage correctly, this does not provide us with transactions right now -- but this patch (on top of #25) reduces the number of commits to a minimum (1 per HTTP request) by moving the `batch` operation into the webdav_api. Certainly this is a bit more fragile for potential users of webdav_fs (since destroy and write should be called within a batch only), but I think that overall it is a benefit. See https://github.com/mirage/mirage-kv/issues/29 for discussion about transactions.