### PR TITLE
If there's a top-level deletion (of a calendar), require the target ACL

### DIFF
--- a/src/privileges.ml
+++ b/src/privileges.ml
@@ -56,7 +56,7 @@ let can_read_prop fqname privileges =
   | ns, "password" when ns = Xml.robur_ns -> false
   | _ -> true
 
-let required verb ~target_exists = match verb with
+let required verb ~is_calendar ~target_exists = match verb with
   | `GET -> `Read, `Target
   | `HEAD -> `Read, `Target
   | `OPTIONS -> `Read, `Target
@@ -65,6 +65,7 @@ let required verb ~target_exists = match verb with
   | `Other "PROPPATCH" -> `Write_properties, `Target
   | `Other "ACL" -> `Write_acl, `Target
   | `Other "PROPFIND" -> `Read, `Target (* plus <D:read-acl> and <D:read-current-user-privilege-set> as needed, see check in Properties.find_many *)
+  | `DELETE when is_calendar -> `Unbind, `Target
   | `DELETE -> `Unbind, `Parent
   | `Other "MKCOL" -> `Bind, `Parent
   | `Other "MKCALENDAR" -> `Bind, `Parent

--- a/src/privileges.mli
+++ b/src/privileges.mli
@@ -8,4 +8,4 @@ val is_met : requirement:Xml.privilege -> Xml.privilege list -> bool
 
 val can_read_prop : Xml.fqname -> Xml.privilege list -> bool
 
-val required : Cohttp.Code.meth -> target_exists:bool -> Xml.privilege * [ `Parent | `Target ]
+val required : Cohttp.Code.meth -> is_calendar:bool -> target_exists:bool -> Xml.privilege * [ `Parent | `Target ]

--- a/src/webdav_api.ml
+++ b/src/webdav_api.ml
@@ -1045,7 +1045,11 @@ module Make(Fs: Webdav_fs.S) = struct
   let access_granted_for_acl fs config http_verb ~path ~user =
     properties_for_current_user fs config user >>= fun auth_user_props ->
     Fs.exists fs path >>= fun target_exists ->
-    let requirement, target_or_parent = Privileges.required http_verb ~target_exists in
+    let is_calendar = match String.split_on_char '/' path with
+      | "" :: "calendars" :: _ :: "" :: [] -> true
+      | _ -> false
+    in
+    let requirement, target_or_parent = Privileges.required http_verb ~is_calendar ~target_exists in
     read_target_or_parent_properties fs path target_or_parent >>= fun resource_props ->
     privilege_met fs requirement ~auth_user_props resource_props >|= function
     | `Forbidden -> false


### PR DESCRIPTION
Previously, in a setting where anyone could create calendars (the default), everyone could delete any calendars